### PR TITLE
Fix for Command Overrides resetting on each update

### DIFF
--- a/core/botClient.js
+++ b/core/botClient.js
@@ -115,7 +115,7 @@ module.exports = class BotClient extends Client {
         // readyClient.guilds.cache.get(serverID).commands.set(commandStructures);
 
         // globally register all application commands
-        readyClient.application.commands.set([]);
+        // readyClient.application.commands.set([]);
         readyClient.application.commands.set(commandStructures);
 
         this.logger.console({


### PR DESCRIPTION
When the discord bot is updated, the command overrides are reset. Likely due to the commands being set to `[]` and then being set again