### PR TITLE
Fixed MMR filter to be minimum inclusive and maximum exclusive

### DIFF
--- a/interactions/commands/sub.js
+++ b/interactions/commands/sub.js
@@ -35,7 +35,7 @@ module.exports = {
                 type: player.status == PlayerStatusCode.FREE_AGENT ? ` FA` : `RFA`,
                 mmr: player.MMR_Player_MMRToMMR?.mmr_overall
             }
-        }).filter(player => player.mmr > capMin && player.mmr <= capMax).sort((a, b) => a.mmr - b.mmr);
+        }).filter(player => player.mmr >= capMin && player.mmr < capMax).sort((a, b) => a.mmr - b.mmr);
 
         // filter by FA/RFA and format with Riot ID and Tracker link
         const descriptionFA = activeSubs


### PR DESCRIPTION
Substitute filters are minimum exclusive and maximum inclusive. They should correctly be (minimum inclusive and maximum exclusive):
```
Mythic     : [ 160, inf )
Expert     : [ 118, 160 )
Apprentice : [  93, 118 )
Prospect   : [   0,  93 )
```
when given the following tier caps:
```js
const tiercaps = {
    prospect: 93,
    apprentice: 118,
    expert: 160,
}; // max MMR for these tiers (mythic has no max MMR)
```
so a player with MMR 160 will be in Mythic, since the filter will inclusively allow that player but exclusively block them.