### PR TITLE
fix broken query for emotes in sign and sub

### DIFF
--- a/src/interactions/subcommands/transactions/sign.js
+++ b/src/interactions/subcommands/transactions/sign.js
@@ -115,7 +115,7 @@ async function confirmSign(interaction) {
 		fields: [
 			{
 				name: `Franchise`,
-				value: `<${team.Franchise.Brand.discordEmote}> ${team.Franchise.name}`,
+				value: `<${franchise.Brand.discordEmote} ${team.Franchise.name}`,
 				inline: true,
 			},
 			{

--- a/src/interactions/subcommands/transactions/sub.js
+++ b/src/interactions/subcommands/transactions/sub.js
@@ -126,7 +126,7 @@ async function confirmSub(interaction) {
 		fields: [
 			{
 				name: `Franchise`,
-				value: `<${franchise.emoteID}> ${franchise.name}`,
+				value: `<${franchise.Brand.discordEmote} ${franchise.name}`,
 				inline: true,
 			},
 			{


### PR DESCRIPTION
@torohangupta Another minor fix as the sub and sign commands had the wrong query for the emote.