### PR TITLE
don't fetch asset URL altogether for banner checks

### DIFF
--- a/src/interactions/commands/profile.js
+++ b/src/interactions/commands/profile.js
@@ -92,18 +92,15 @@ async function user(/** @type ChatInputCommandInteraction */ interaction) {
 		}
 	}
 	
-	if (guildUserBanner !== player.banner){
-		const bannerResponse = await fetch(player.banner)
-		if (!bannerResponse.ok) {
-			logger.log(`DEBUG`, `Player ${player.id}'s discord banner from the database is invalid. Attempting to update...`);
-			const user = await prisma.user.update({
-				where: { id: player.id },
-				data: { banner: guildUserBanner },
-			});
-			if (user.banner !== guildUserBanner) logger.log(`ERROR`, `Failed to update player ${player.id}'s discord banner in our DB. Silently failing...`)
-			else {
-				logger.log(`INFO`, `Successfully updated player ${player.id}'s discord banner in our DB.`)
-			}
+	if (guildUserBanner !== player.banner) {
+		logger.log(`DEBUG`, `Player ${player.id}'s discord banner from the database does not match one from discord. Attempting to update...`);
+		const user = await prisma.user.update({
+			where: { id: player.id },
+			data: { banner: guildUserBanner },
+		});
+		if (user.banner !== guildUserBanner) logger.log(`ERROR`, `Failed to update player ${player.id}'s discord banner in our DB. Silently failing...`)
+		else {
+			logger.log(`INFO`, `Successfully updated player ${player.id}'s discord banner in our DB.`)
 		}
 	}
 	const riotAccounts = player.Accounts.filter(a => a.provider === `riot`).map(a => `[\`${a.riotIGN}\`](${`https://tracker.gg/valorant/profile/riot/${encodeURIComponent(a.riotIGN)}`})`).join(`, `)
@@ -631,24 +628,24 @@ async function update(/** @type ChatInputCommandInteraction */ interaction) {
 	const guildUserBanner = user.bannerURL({ dynamic: true, size: 2048 });
 	
 	if (guildUserBanner !== player.banner) {
-		const bannerLookup = await fetch(player.banner)
-		if (!bannerLookup.ok){
-			progress[progress.length - 1] = `🤔 Seems like you changed your banner. We'll try to update it.`;
-			await interaction.editReply(progress.join(`\n`));
+		progress[progress.length - 1] = `🤔 Seems like you changed your banner. We'll try to update it.`;
+		await interaction.editReply(progress.join(`\n`));
+		
+		const user = await prisma.user.update({
+			where: { id: player.id },
+			data: { banner: guildUserBanner },
+		});
 
-			const user = await prisma.user.update({
-				where: { id: player.id },
-				data: { banner: guildUserBanner },
-			});
-
-			if (user.banner !== guildUserBanner) {
-				progress[progress.length - 1] = 
-					`❌ Looks like there was an error and the database wasn't updated! Please try again later and/or let a member of the tech team know!`;
-			}
-			else progress[progress.length - 1] = `✅ Your banner has been updated!`
-			await interaction.editReply(progress.join(`\n`));
+		if (user.banner !== guildUserBanner) {
+			progress[progress.length - 1] = 
+				`❌ Looks like there was an error and the database wasn't updated! Please try again later and/or let a member of the tech team know!`;
 		}
+		else progress[progress.length - 1] = `✅ Your banner has been updated!`
+		await interaction.editReply(progress.join(`\n`));
 	}
+	
+	progress[progress.length - 1] = `✅ Your pfp/banner have been updated!`;
+	await interaction.editReply(progress.join(`\n`));
 	// --------------------------------------------------------------------------------------------
 
 	// lastly, update meilisearch to contain their new information

--- a/src/interactions/subcommands/debug/profileUpdateServer.js
+++ b/src/interactions/subcommands/debug/profileUpdateServer.js
@@ -426,19 +426,15 @@ async function update(
 	const guildUserBanner = user.bannerURL({ dynamic: true, size: 2048 });
 	
 	if (guildUserBanner !== player.banner) {
-		const bannerLookup = await fetch(player.banner)
-		if (!bannerLookup.ok){
-            logger.log(`INFO`, `Player \`${player.name}\` (\`${player.id}\`) updated their banner. Attempting to update...`);
+        logger.log(`INFO`, `Player \`${player.name}\` (\`${player.id}\`) updated their banner. Attempting to update...`);
+        const user = await prisma.user.update({
+            where: { id: player.id },
+            data: { banner: guildUserBanner },
+        });
 
-			const user = await prisma.user.update({
-				where: { id: player.id },
-				data: { banner: guildUserBanner },
-			});
-
-			if (user.banner !== guildUserBanner) {
-                logger.log(`WARNING`, `Looks like there was an error updating the database for \`${player.name}\` (\`${player.id}\`)'s banner!`);
-			}
-		}
+        if (user.banner !== guildUserBanner) {
+            logger.log(`WARNING`, `Looks like there was an error updating the database for \`${player.name}\` (\`${player.id}\`)'s banner!`);
+        }
 	}
     // --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR adds new features and fixes.

| Version | Notes |
| - | - |
| x.x.x  | VERSION_NOTES |

### Changes:
- skip asset URL fetching altogether since the data from discord is the only source of truth.
- this avoids null error from fetching if the data from db is null