### PR TITLE
added optional tier argument to queue status

### DIFF
--- a/src/interactions/commands/queue.js
+++ b/src/interactions/commands/queue.js
@@ -30,7 +30,8 @@ module.exports = {
 		}
 
 		if (subcommand === `status`) {
-			return status(interaction);
+			const tier = interaction.options.getString(`tier`, false);
+			return status(interaction, tier);
 		}
 
 		return joinQueue(interaction, queueConfig);

--- a/src/interactions/subcommands/queue/status.js
+++ b/src/interactions/subcommands/queue/status.js
@@ -1,8 +1,95 @@
-const { MessageFlags, EmbedBuilder } = require(`discord.js`);
+const { MessageFlags, EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require(`discord.js`);
 const { getRedisClient } = require(`../../../core/redis`);
 const { TIERS_SET_KEY, tierQueueKeys, matchKeyPattern } = require(`../../../helpers/queue/queueKeys`);
 
-async function status(interaction) {
+const MAX_EMBED_FIELDS = 25; // Discord's limit for fields in an embed. needed to paginate tier specific queue results
+
+async function getQueueTierStatus(interaction, tier_arg) {
+    const listKeys = tierQueueKeys(tier_arg, { includeCompleted: false });
+    const rows = [];
+    const paginatedEmbeds = [];
+
+    //i have no clue if this is how you get the users in the queue from redis. change this if needed
+    //this is my best guess because idk what the structure of the queue data is
+    const results = await Promise.all(listKeys.map((k) => redis.lrange(k, 0, -1).catch(() => [])));
+
+    const byBucket = Object.fromEntries(
+        QUEUE_BUCKETS.map((bucket, i) => [bucket, results[i]])
+    );
+
+    for (const [bucket, users] of Object.entries(byBucket)) {
+        for (const u of users) {
+            rows.push({ status: bucket, user: u });
+        }
+    }
+
+    const userCount = results.flat().length;
+
+    const embed = new EmbedBuilder()
+        .setTitle(`Queued members in ${tier_arg} (${userCount})`)
+        .setColor(0x5865F2);
+
+    if (userCount > MAX_EMBED_FIELDS) {
+        // paginate results
+        for (let i = 0; i < rows.length; i += MAX_EMBED_FIELDS) {
+            const pageRows = rows.slice(i, i + MAX_EMBED_FIELDS);
+            const pageEmbed = embed.clone();
+            for (const r of pageRows) {
+                pageEmbed.addFields({ name: r.status, value: r.user, inline: true });
+            }
+            paginatedEmbeds.push(pageEmbed);
+        }
+
+        let currentPage = 0;
+
+        const prevButton = new ButtonBuilder()
+            .setCustomId('prev')
+            .setLabel('Previous')
+            .setStyle(ButtonStyle.Primary)
+            .setDisabled(true); // disabled on first page
+
+        const nextButton = new ButtonBuilder()
+            .setCustomId('next')
+            .setLabel('Next')
+            .setStyle(ButtonStyle.Primary)
+            .setDisabled(currentPage === paginatedEmbeds.length - 1);
+
+        const buttons = new ActionRowBuilder().addComponents(prevButton, nextButton);
+        const reply = await interaction.editReply({ embeds: [paginatedEmbeds[currentPage]], components: [buttons] });
+        const collector = reply.createMessageComponentCollector({ time: 60_000 });
+
+        collector.on('collect', async (buttonInteraction) => {
+
+            if (buttonInteraction.customId === 'prev') currentPage--;
+            if (buttonInteraction.customId === 'next') currentPage++;
+
+            prevButton.setDisabled(currentPage === 0);
+            nextButton.setDisabled(currentPage === paginatedEmbeds.length - 1);
+
+            await buttonInteraction.update({
+                embeds: [paginatedEmbeds[currentPage]],
+                components: [new ActionRowBuilder().addComponents(prevButton, nextButton)],
+            });
+        });
+
+        // Disable buttons when the collector expires
+        collector.on('end', async () => {
+            prevButton.setDisabled(true);
+            nextButton.setDisabled(true);
+            await interaction.editReply({ components: [new ActionRowBuilder().addComponents(prevButton, nextButton)] });
+        });
+
+    }
+    else {
+        for (const r of rows) {
+            embed.addFields({ name: `${r.status}`, value: ` ${r.user}`, inline: true });
+        }
+    }
+
+    return interaction.editReply({ embeds: [embed] });
+}
+
+async function status(interaction, tier_arg) {
     await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
     const redis = getRedisClient();
@@ -13,6 +100,15 @@ async function status(interaction) {
         }
 
         const rows = [];
+
+        if (tier_arg) {
+            if (!tiers.includes(tier_arg)) {
+                return interaction.editReply({ content: `Tier "${tier_arg}" does not exist.` });
+            }
+            else {
+                return getQueueTierStatus(interaction, tier_arg);
+            }
+        }
 
         // Build base tier queue counts
         for (const tier of tiers) {


### PR DESCRIPTION
**I have not tested this code. Please test it yourself or let me know how I can test it if needed (or don't flame me if it breaks anything)**

Added optional tier command to /queue status. Given a tier, it will show all of the users in queue, paginating the results across multiple embeds if the user count for a queue exceeds 25