### PR TITLE
race condition causing bot to unsub even when a player is signed

### DIFF
--- a/src/helpers/transactions/activeSubTimers.js
+++ b/src/helpers/transactions/activeSubTimers.js
@@ -1,0 +1,36 @@
+/**
+ * In-memory registry of pending auto-unsub timers, keyed by the player's
+ * internal database id. When a player is subbed in, sub.js arms a timer that
+ * will unsub them after the active sub window elapses. If that player is
+ * officially signed or cut before the window ends, the owning command cancels
+ * the timer here so a stale auto-unsub can't drop them from their roster.
+ *
+ * Note: these timers live only in this process, so a bot restart still loses
+ * any pending auto-unsub. Persisting sub expiry across restarts is tracked
+ * separately.
+ */
+
+const pendingUnsubTimers = new Map();
+
+function registerUnsubTimer(playerID, timerHandle) {
+	cancelUnsubTimer(playerID);
+	pendingUnsubTimers.set(playerID, timerHandle);
+}
+
+function cancelUnsubTimer(playerID) {
+	const existingTimer = pendingUnsubTimers.get(playerID);
+	if (existingTimer === undefined) return;
+
+	clearTimeout(existingTimer);
+	pendingUnsubTimers.delete(playerID);
+}
+
+function clearUnsubTimer(playerID) {
+	pendingUnsubTimers.delete(playerID);
+}
+
+module.exports = {
+	registerUnsubTimer: registerUnsubTimer,
+	cancelUnsubTimer: cancelUnsubTimer,
+	clearUnsubTimer: clearUnsubTimer,
+};

--- a/src/interactions/subcommands/transactions/cut.js
+++ b/src/interactions/subcommands/transactions/cut.js
@@ -9,6 +9,7 @@ const { prisma } = require("../../../../prisma/prismadb");
 
 const Logger = require("../../../core/logger");
 const { updateMeilisearchPlayer } = require("../../../../utils/web/vdcWeb");
+const { cancelUnsubTimer } = require("../../../helpers/transactions/activeSubTimers");
 const logger = new Logger();
 
 const imagepath = `https://uni-objects.nyc3.cdn.digitaloceanspaces.com/vdc/team-logos/`;
@@ -117,6 +118,9 @@ async function confirmCut(/** @type ButtonInteraction */ interaction) {
 	// cut the player & ensure that the player's team property is now null
 	const player = await Transaction.cut(playerID);
 	if (player.User.team !== null) return await interaction.editReply(`There was an error while attempting to cut the player. The database was not updated.`);
+
+	// the player is now cut, so cancel any pending auto-unsub from a prior sub
+	cancelUnsubTimer(playerData.id);
 
 	const embed = interaction.message.embeds[0];
 	const embedEdits = new EmbedBuilder(embed);

--- a/src/interactions/subcommands/transactions/sign.js
+++ b/src/interactions/subcommands/transactions/sign.js
@@ -9,6 +9,7 @@ const { prisma } = require("../../../../prisma/prismadb");
 
 const Logger = require("../../../core/logger");
 const { updateMeilisearchPlayer } = require("../../../../utils/web/vdcWeb");
+const { cancelUnsubTimer } = require("../../../helpers/transactions/activeSubTimers");
 const logger = new Logger();
 
 const imagepath = `https://uni-objects.nyc3.cdn.digitaloceanspaces.com/vdc/team-logos/`;
@@ -105,6 +106,9 @@ async function confirmSign(interaction) {
 	const isGM = playerData.Status.leagueStatus === LeagueStatus.GENERAL_MANAGER;
 	const player = await Transaction.sign({ userID: playerData.id, teamID: team.id, isGM: isGM, contractLength: contractLength });
 	if (player.team !== team.id) return await interaction.editReply({ content: `There was an error while attempting to sign the player. The database was not updated.` });
+
+	// the player is now officially signed, so cancel any pending auto-unsub from a prior sub
+	cancelUnsubTimer(playerData.id);
 
 	const embed = interaction.message.embeds[0];
 	const embedEdits = new EmbedBuilder(embed);

--- a/src/interactions/subcommands/transactions/sub.js
+++ b/src/interactions/subcommands/transactions/sub.js
@@ -5,6 +5,7 @@ const { ChatInputCommandInteraction, GuildMember } = require(`discord.js`);
 const { Franchise, Player, Team, Transaction, ControlPanel } = require(`../../../../prisma`);
 const { CHANNELS, TransactionsNavigationOptions } = require(`../../../../utils/enums`);
 const { LeagueStatus, ContractStatus } = require("@prisma/client");
+const { registerUnsubTimer, clearUnsubTimer } = require(`../../../helpers/transactions/activeSubTimers`);
 
 const sum = (array) => array.reduce((s, v) => s += v == null ? 0 : v, 0);
 
@@ -141,7 +142,19 @@ async function confirmSub(interaction) {
 	const transactionsChannel = await interaction.guild.channels.fetch(CHANNELS.TRANSACTIONS);
 	await transactionsChannel.send({ embeds: [announcement] });
 
-	setTimeout(async () => {
+	const unsubTimerHandle = setTimeout(async () => {
+		clearUnsubTimer(player.id);
+
+		// The player may have been officially signed or cut during the active sub
+		// window, which clears their ACTIVE_SUB status. Re-fetch and only auto-unsub
+		// if they're still an active sub on the same team, otherwise this stale timer
+		// would wrongly drop a now-signed player from their roster.
+		const currentPlayer = await Player.getBy({ userID: player.id });
+		const isStillActiveSubForTeam =
+			currentPlayer?.Status.contractStatus === ContractStatus.ACTIVE_SUB &&
+			currentPlayer.team === team.id;
+		if (!isStillActiveSubForTeam) return;
+
 		// unsub the player & ensure that the player's team property is now null
 		const updatedPlayer = await Transaction.unsub(player.id);
 		if (updatedPlayer.team !== null) return await interaction.channel.send(`There was an error while attempting to unsub ${guildMember} (${playerTag}). The database was not updated.`);
@@ -160,6 +173,8 @@ async function confirmSub(interaction) {
 
 		return await transactionsChannel.send({ embeds: [announcement] });
 	}, activeSubTime);
+
+	registerUnsubTimer(player.id, unsubTimerHandle);
 }
 module.exports = {
 	requestSub: requestSub,


### PR DESCRIPTION
This PR adds fixes.

| Version | Notes |
| - | - |
| 2.0.2  | Sub/Unsub/Sign bugfix |

### Changes:
There was an instance where a player was subbed, then immediately signed. When the 12 hour auto unsub timer was depleted, the player was effectively cut from the team they were officially signed to. This change cancels the orphaned 12 hour unsub if a player gets signed/cut.