### PR TITLE
Transaction Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ package-lock.json
 utils/commandsStructure/test.js
 src/interactions/commands/test.js
 pnpm-lock.yaml
+docs
 ################################################################
 
 clear-discord-commands.js

--- a/src/helpers/transactions/activeSubTimers.js
+++ b/src/helpers/transactions/activeSubTimers.js
@@ -1,0 +1,36 @@
+/**
+ * In-memory registry of pending auto-unsub timers, keyed by the player's
+ * internal database id. When a player is subbed in, sub.js arms a timer that
+ * will unsub them after the active sub window elapses. If that player is
+ * officially signed or cut before the window ends, the owning command cancels
+ * the timer here so a stale auto-unsub can't drop them from their roster.
+ *
+ * Note: these timers live only in this process, so a bot restart still loses
+ * any pending auto-unsub. Persisting sub expiry across restarts is tracked
+ * separately.
+ */
+
+const pendingUnsubTimers = new Map();
+
+function registerUnsubTimer(playerID, timerHandle) {
+	cancelUnsubTimer(playerID);
+	pendingUnsubTimers.set(playerID, timerHandle);
+}
+
+function cancelUnsubTimer(playerID) {
+	const existingTimer = pendingUnsubTimers.get(playerID);
+	if (existingTimer === undefined) return;
+
+	clearTimeout(existingTimer);
+	pendingUnsubTimers.delete(playerID);
+}
+
+function clearUnsubTimer(playerID) {
+	pendingUnsubTimers.delete(playerID);
+}
+
+module.exports = {
+	registerUnsubTimer: registerUnsubTimer,
+	cancelUnsubTimer: cancelUnsubTimer,
+	clearUnsubTimer: clearUnsubTimer,
+};

--- a/src/helpers/transactions/formatTeam.js
+++ b/src/helpers/transactions/formatTeam.js
@@ -1,0 +1,18 @@
+const TIER_LABELS = {
+  RECRUIT: `Recruit`,
+  PROSPECT: `Prospect`,
+  APPRENTICE: `Apprentice`,
+  EXPERT: `Expert`,
+  MYTHIC: `Mythic`,
+  MIXED: `Mixed`,
+};
+
+function tierLabel(tier) {
+  return TIER_LABELS[tier] ?? tier;
+}
+
+function formatTeamWithTier(team) {
+  return `${team.name} (${tierLabel(team.tier)})`;
+}
+
+module.exports = { tierLabel, formatTeamWithTier };

--- a/src/helpers/transactions/logTransaction.js
+++ b/src/helpers/transactions/logTransaction.js
@@ -1,0 +1,18 @@
+const { Transaction } = require(`../../../prisma`);
+const Logger = require(`../../core/logger`);
+
+const logger = new Logger();
+
+/** Writes to transaction history row. This never throws: by the time it
+ * runs the roster mutation has already committed, so a logging failure must not surface
+ * to the user or block the announcement. Callers supply only the six transaction columns
+ * (the current season is resolved inside Transaction.log). */
+async function logTransaction(options) {
+	try {
+		await Transaction.log(options);
+	} catch (error) {
+		logger.log(`WARNING`, `Failed to record ${options.type} transaction: ${error.message}`);
+	}
+}
+
+module.exports = { logTransaction };

--- a/src/interactions/commands/profile.js
+++ b/src/interactions/commands/profile.js
@@ -154,7 +154,7 @@ async function update(/** @type ChatInputCommandInteraction */ interaction) {
 	await interaction.editReply(progress.join(`\n`));
 
 	const player = await Player.getBy({ discordID: userID });
-	if (!player.primaryRiotAccountID) {
+	if (!player || !player.primaryRiotAccountID) {
 		progress[progress.length - 1] =
 			`❌ I looked through our database and I don't see your Riot account linked anywhere! Please link one [here](https://vdc.gg/me)!`;
 		return await interaction.editReply(progress.join(`\n`));

--- a/src/interactions/subcommands/transactions/captain.js
+++ b/src/interactions/subcommands/transactions/captain.js
@@ -4,6 +4,9 @@ const { ChatInputCommandInteraction, GuildMember } = require(`discord.js`);
 
 const { Franchise, Player, Team, Transaction, Roles } = require(`../../../../prisma`);
 const { ROLES, CHANNELS, TransactionsNavigationOptions } = require(`../../../../utils/enums`);
+const { formatTeamWithTier } = require(`../../../helpers/transactions/formatTeam`);
+const { logTransaction } = require(`../../../helpers/transactions/logTransaction`);
+const { TransactionType } = require(`@prisma/client`);
 const { ContractStatus } = require("@prisma/client");
 
 const emoteregex = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
@@ -103,6 +106,15 @@ async function confirmToggleCaptain(interaction, mode) {
 	if (updatedTeam.captain === null && mode == `SET`) return await interaction.editReply(`There was an error while attempting to set the player as a captain. The database was not updated.`);
 	if (updatedTeam.captain !== null && mode == `REMOVE`) return await interaction.editReply(`There was an error while attempting to remove the player as a captain. The database was not updated.`);
 
+	await logTransaction({
+		type: TransactionType.CAPTAIN,
+		userID: playerData.id,
+		teamID: team.id,
+		franchiseID: team.Franchise.id,
+		tier: team.tier,
+		details: { mode: mode },
+	});
+
 	const embed = interaction.message.embeds[0];
 	const embedEdits = new EmbedBuilder(embed);
 	embedEdits.setDescription(`This operation was successfully completed.`);
@@ -120,8 +132,8 @@ async function confirmToggleCaptain(interaction, mode) {
 		timestamp: Date.now(),
 	});
 
-	if (mode === `SET`) announcement.setDescription(`${guildMember} (${playerTag}) is now the captain for ${updatedTeam.name}`)
-	else announcement.setDescription(`${guildMember} (${playerTag}) is no longer the captain for ${updatedTeam.name}`)
+	if (mode === `SET`) announcement.setDescription(`${guildMember} (${playerTag}) is now the captain for ${formatTeamWithTier(team)}`)
+	else announcement.setDescription(`${guildMember} (${playerTag}) is no longer the captain for ${formatTeamWithTier(team)}`)
 
 	await interaction.deleteReply();
 	const transactionsChannel = await interaction.guild.channels.fetch(CHANNELS.TRANSACTIONS);

--- a/src/interactions/subcommands/transactions/cut.js
+++ b/src/interactions/subcommands/transactions/cut.js
@@ -4,12 +4,14 @@ const { ChatInputCommandInteraction, GuildMember, ButtonInteraction } = require(
 
 const { Franchise, Player, Team, Transaction, ControlPanel } = require(`../../../../prisma`);
 const { ROLES, CHANNELS, TransactionsNavigationOptions } = require(`../../../../utils/enums`);
-const { Tier } = require("@prisma/client");
+const { Tier, TransactionType } = require("@prisma/client");
 const { prisma } = require("../../../../prisma/prismadb");
 
 const Logger = require("../../../core/logger");
 const { updateMeilisearchPlayer } = require("../../../../utils/web/vdcWeb");
 const { cancelUnsubTimer } = require("../../../helpers/transactions/activeSubTimers");
+const { tierLabel } = require("../../../helpers/transactions/formatTeam");
+const { logTransaction } = require("../../../helpers/transactions/logTransaction");
 const logger = new Logger();
 
 const imagepath = `https://uni-objects.nyc3.cdn.digitaloceanspaces.com/vdc/team-logos/`;
@@ -122,6 +124,14 @@ async function confirmCut(/** @type ButtonInteraction */ interaction) {
 	// the player is now cut, so cancel any pending auto-unsub from a prior sub
 	cancelUnsubTimer(playerData.id);
 
+	await logTransaction({
+		type: TransactionType.CUT,
+		userID: playerData.id,
+		teamID: team.id,
+		franchiseID: franchise.id,
+		tier: team.tier,
+	});
+
 	const embed = interaction.message.embeds[0];
 	const embedEdits = new EmbedBuilder(embed);
 	embedEdits.setDescription(`This operation was successfully completed.`);
@@ -145,6 +155,11 @@ async function confirmCut(/** @type ButtonInteraction */ interaction) {
 			{
 				name: `Team`,
 				value: team.name,
+				inline: true,
+			},
+			{
+				name: `Tier`,
+				value: tierLabel(team.tier),
 				inline: true,
 			},
 		],

--- a/src/interactions/subcommands/transactions/cut.js
+++ b/src/interactions/subcommands/transactions/cut.js
@@ -9,6 +9,7 @@ const { prisma } = require("../../../../prisma/prismadb");
 
 const Logger = require("../../../core/logger");
 const { updateMeilisearchPlayer } = require("../../../../utils/web/vdcWeb");
+const { cancelUnsubTimer } = require("../../../helpers/transactions/activeSubTimers");
 const logger = new Logger();
 
 const imagepath = `https://uni-objects.nyc3.cdn.digitaloceanspaces.com/vdc/team-logos/`;
@@ -117,6 +118,9 @@ async function confirmCut(/** @type ButtonInteraction */ interaction) {
 	// cut the player & ensure that the player's team property is now null
 	const player = await Transaction.cut(playerID);
 	if (player.User.team !== null) return await interaction.editReply(`There was an error while attempting to cut the player. The database was not updated.`);
+
+	// the player is now cut, so cancel any pending auto-unsub from a prior sub
+	cancelUnsubTimer(playerData.id);
 
 	const embed = interaction.message.embeds[0];
 	const embedEdits = new EmbedBuilder(embed);

--- a/src/interactions/subcommands/transactions/expire.js
+++ b/src/interactions/subcommands/transactions/expire.js
@@ -5,7 +5,9 @@ const { ChatInputCommandInteraction, GuildMember } = require(`discord.js`);
 const { Player, Team, Transaction, Franchise, Flags } = require(`../../../../prisma`);
 const { ROLES, CHANNELS, TransactionsNavigationOptions } = require(`../../../../utils/enums`);
 const { prisma } = require("../../../../prisma/prismadb");
-const { Tier } = require("@prisma/client");
+const { Tier, TransactionType } = require("@prisma/client");
+const { tierLabel } = require("../../../helpers/transactions/formatTeam");
+const { logTransaction } = require("../../../helpers/transactions/logTransaction");
 
 
 const Logger = require("../../../core/logger");
@@ -122,6 +124,14 @@ async function confirmExpire(interaction) {
 	const status = await Transaction.cut(playerID);
 	if (status.contractRemaining != null) return await interaction.editReply(`There was an error while attempting to finalize the expiration of the player's contract. The database was not updated.`);
 
+	await logTransaction({
+		type: TransactionType.EXPIRE,
+		userID: playerData.id,
+		teamID: team.id,
+		franchiseID: franchise.id,
+		tier: team.tier,
+	});
+
 	const embed = interaction.message.embeds[0];
 	const embedEdits = new EmbedBuilder(embed);
 	embedEdits.setDescription(`This operation was successfully completed.`);
@@ -145,6 +155,11 @@ async function confirmExpire(interaction) {
 			{
 				name: `Team`,
 				value: team.name,
+				inline: true,
+			},
+			{
+				name: `Tier`,
+				value: tierLabel(team.tier),
 				inline: true,
 			},
 		],

--- a/src/interactions/subcommands/transactions/ir.js
+++ b/src/interactions/subcommands/transactions/ir.js
@@ -4,8 +4,10 @@ const { ChatInputCommandInteraction, GuildMember } = require(`discord.js`);
 
 const { Franchise, Player, Team, Transaction } = require(`../../../../prisma`);
 const { ROLES, CHANNELS, TransactionsNavigationOptions } = require(`../../../../utils/enums`);
-const { ContractStatus } = require("@prisma/client");
+const { ContractStatus, TransactionType } = require("@prisma/client");
 const { updateMeilisearchPlayer } = require("../../../../utils/web/vdcWeb");
+const { tierLabel } = require("../../../helpers/transactions/formatTeam");
+const { logTransaction } = require("../../../helpers/transactions/logTransaction");
 
 const emoteregex = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
 
@@ -102,6 +104,15 @@ async function confirmToggleIR(interaction, mode) {
 	if (player.Status.contractStatus !== ContractStatus.INACTIVE_RESERVE && mode == `SET`) return await interaction.editReply(`There was an error while attempting to place the player on Inactive Reserve. The database was not updated.`);
 	if (player.Status.contractStatus === ContractStatus.INACTIVE_RESERVE && mode == `REMOVE`) return await interaction.editReply(`There was an error while attempting to remove the player from Inactive Reserve. The database was not updated.`);
 
+	await logTransaction({
+		type: TransactionType.IR,
+		userID: playerData.id,
+		teamID: team.id,
+		franchiseID: team.Franchise.id,
+		tier: team.tier,
+		details: { mode: mode },
+	});
+
 	const embed = interaction.message.embeds[0];
 	const embedEdits = new EmbedBuilder(embed);
 	embedEdits.setDescription(`This operation was successfully completed.`);
@@ -115,6 +126,23 @@ async function confirmToggleIR(interaction, mode) {
 			url: `https://uni-objects.nyc3.cdn.digitaloceanspaces.com/vdc/team-logos/${team.Franchise.Brand.logo}`,
 		},
 		color: 0xe92929,
+		fields: [
+			{
+				name: `Franchise`,
+				value: `<${team.Franchise.Brand.discordEmote}> ${team.Franchise.name}`,
+				inline: true,
+			},
+			{
+				name: `Team`,
+				value: team.name,
+				inline: true,
+			},
+			{
+				name: `Tier`,
+				value: tierLabel(team.tier),
+				inline: true,
+			},
+		],
 		footer: { text: `Transactions — Inactive Reserve` },
 		timestamp: Date.now(),
 	});

--- a/src/interactions/subcommands/transactions/ir.js
+++ b/src/interactions/subcommands/transactions/ir.js
@@ -105,12 +105,11 @@ async function confirmToggleIR(interaction, mode) {
 	if (player.Status.contractStatus === ContractStatus.INACTIVE_RESERVE && mode == `REMOVE`) return await interaction.editReply(`There was an error while attempting to remove the player from Inactive Reserve. The database was not updated.`);
 
 	await logTransaction({
-		type: TransactionType.IR,
+		type: mode === `SET` ? TransactionType.IR : TransactionType.ACTIVATE,
 		userID: playerData.id,
 		teamID: team.id,
 		franchiseID: team.Franchise.id,
 		tier: team.tier,
-		details: { mode: mode },
 	});
 
 	const embed = interaction.message.embeds[0];

--- a/src/interactions/subcommands/transactions/renew.js
+++ b/src/interactions/subcommands/transactions/renew.js
@@ -4,6 +4,9 @@ const { ChatInputCommandInteraction, GuildMember } = require(`discord.js`);
 
 const { Player, Team, Transaction, Franchise } = require(`../../../../prisma`);
 const { ROLES, CHANNELS, TransactionsNavigationOptions } = require(`../../../../utils/enums`);
+const { tierLabel } = require(`../../../helpers/transactions/formatTeam`);
+const { logTransaction } = require(`../../../helpers/transactions/logTransaction`);
+const { TransactionType } = require(`@prisma/client`);
 
 const emoteregex = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
 
@@ -79,6 +82,15 @@ async function confirmRenew(interaction) {
 	const status = await Transaction.renew(playerData.id);
 	if (status.contractRemaining !== 1) return await interaction.editReply(`There was an error while attempting to renew the player's contract. The database was not updated.`);
 
+	await logTransaction({
+		type: TransactionType.RENEW,
+		userID: playerData.id,
+		teamID: team.id,
+		franchiseID: franchise.id,
+		tier: team.tier,
+		details: { contractRemaining: 1 },
+	});
+
 	const embed = interaction.message.embeds[0];
 	const embedEdits = new EmbedBuilder(embed);
 	embedEdits.setDescription(`This operation was successfully completed.`);
@@ -102,6 +114,11 @@ async function confirmRenew(interaction) {
 			{
 				name: `Team`,
 				value: team.name,
+				inline: true,
+			},
+			{
+				name: `Tier`,
+				value: tierLabel(team.tier),
 				inline: true,
 			},
 		],

--- a/src/interactions/subcommands/transactions/reschedule.js
+++ b/src/interactions/subcommands/transactions/reschedule.js
@@ -5,7 +5,8 @@ const { ChatInputCommandInteraction, GuildMember } = require(`discord.js`);
 const { Player, Team, Transaction, Franchise, ControlPanel } = require(`../../../../prisma`);
 const { ROLES, CHANNELS, TransactionsNavigationOptions } = require(`../../../../utils/enums`);
 const { prisma } = require("../../../../prisma/prismadb");
-const { MatchType } = require("@prisma/client");
+const { MatchType, TransactionType } = require("@prisma/client");
+const { logTransaction } = require("../../../helpers/transactions/logTransaction");
 
 const emoteregex = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
 
@@ -91,11 +92,18 @@ async function confirmReschedule(interaction) {
         .replaceAll(`\``, ``).split(`\n`);
 
     const teams = params[1].split(` vs. `);
+    const tier = params[2];
     const timestamp = params[3];
     const matchID = Number(params[5]);
     const datetime = new Date(params[4]);
 
     await Transaction.reschedule(matchID, datetime);
+
+    await logTransaction({
+        type: TransactionType.RESCHEDULE,
+        tier: tier,
+        details: { matchID: matchID, teams: teams, newDate: datetime.toISOString() },
+    });
 
     const embed = interaction.message.embeds[0];
     const embedEdits = new EmbedBuilder(embed);

--- a/src/interactions/subcommands/transactions/retire.js
+++ b/src/interactions/subcommands/transactions/retire.js
@@ -5,8 +5,9 @@ const { ChatInputCommandInteraction, GuildMember } = require(`discord.js`);
 const { Player, Transaction } = require(`../../../../prisma`);
 const { ROLES, CHANNELS, TransactionsNavigationOptions } = require(`../../../../utils/enums`);
 const { prisma } = require("../../../../prisma/prismadb");
-const { LeagueStatus } = require("@prisma/client");
+const { LeagueStatus, TransactionType } = require("@prisma/client");
 const { updateMeilisearchPlayer } = require("../../../../utils/web/vdcWeb");
+const { logTransaction } = require("../../../helpers/transactions/logTransaction");
 
 const emoteregex = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
 
@@ -85,6 +86,11 @@ async function confirmRetire(interaction) {
 
 	const retiredPlayer = await Transaction.retire(playerID);
 	if (retiredPlayer.User.Status.leagueStatus !== LeagueStatus.RETIRED) return await interaction.editReply(`There was an error while attempting to retire the player. The database was not updated.`);
+
+	await logTransaction({
+		type: TransactionType.RETIRE,
+		userID: playerData.id,
+	});
 
 	const embed = interaction.message.embeds[0];
 	const embedEdits = new EmbedBuilder(embed);

--- a/src/interactions/subcommands/transactions/schedule-playoff.js
+++ b/src/interactions/subcommands/transactions/schedule-playoff.js
@@ -4,7 +4,8 @@ const { ChatInputCommandInteraction } = require(`discord.js`);
 const { Team, ControlPanel } = require(`../../../../prisma`);
 const { CHANNELS, TransactionsNavigationOptions } = require(`../../../../utils/enums`);
 const { prisma } = require("../../../../prisma/prismadb");
-const { Tier, MatchType } = require("@prisma/client");
+const { Tier, MatchType, TransactionType } = require("@prisma/client");
+const { logTransaction } = require("../../../helpers/transactions/logTransaction");
 
 const timestampValidator = /(?<=<t:)\d+(?=:\S>)/;
 
@@ -129,6 +130,18 @@ async function confirmSchedulePlayoff(interaction) {
 					} 
 				} 
 			}
+		});
+
+		await logTransaction({
+			type: TransactionType.SCHEDULE_PLAYOFF,
+			tier: tier,
+			details: {
+				matchID: newMatch.matchID,
+				matchType: matchType,
+				home: newMatch.Home.name,
+				away: newMatch.Away.name,
+				scheduledFor: dateTime.toISOString(),
+			},
 		});
 
 		const embedEdits = new EmbedBuilder(embedData);

--- a/src/interactions/subcommands/transactions/sign.js
+++ b/src/interactions/subcommands/transactions/sign.js
@@ -9,6 +9,7 @@ const { prisma } = require("../../../../prisma/prismadb");
 
 const Logger = require("../../../core/logger");
 const { updateMeilisearchPlayer } = require("../../../../utils/web/vdcWeb");
+const { cancelUnsubTimer } = require("../../../helpers/transactions/activeSubTimers");
 const logger = new Logger();
 
 const imagepath = `https://uni-objects.nyc3.cdn.digitaloceanspaces.com/vdc/team-logos/`;
@@ -105,6 +106,9 @@ async function confirmSign(interaction) {
 	const isGM = playerData.Status.leagueStatus === LeagueStatus.GENERAL_MANAGER;
 	const player = await Transaction.sign({ userID: playerData.id, teamID: team.id, isGM: isGM, contractLength: contractLength });
 	if (player.team !== team.id) return await interaction.editReply({ content: `There was an error while attempting to sign the player. The database was not updated.` });
+
+	// the player is now officially signed, so cancel any pending auto-unsub from a prior sub
+	cancelUnsubTimer(playerData.id);
 
 	const embed = interaction.message.embeds[0];
 	const embedEdits = new EmbedBuilder(embed);

--- a/src/interactions/subcommands/transactions/sign.js
+++ b/src/interactions/subcommands/transactions/sign.js
@@ -4,12 +4,14 @@ const { ChatInputCommandInteraction, GuildMember } = require(`discord.js`);
 
 const { Franchise, Player, Team, Transaction, ControlPanel } = require(`../../../../prisma`);
 const { ROLES, CHANNELS, TransactionsNavigationOptions } = require(`../../../../utils/enums`);
-const { LeagueStatus } = require("@prisma/client");
+const { LeagueStatus, TransactionType } = require("@prisma/client");
 const { prisma } = require("../../../../prisma/prismadb");
 
 const Logger = require("../../../core/logger");
 const { updateMeilisearchPlayer } = require("../../../../utils/web/vdcWeb");
 const { cancelUnsubTimer } = require("../../../helpers/transactions/activeSubTimers");
+const { tierLabel } = require("../../../helpers/transactions/formatTeam");
+const { logTransaction } = require("../../../helpers/transactions/logTransaction");
 const logger = new Logger();
 
 const imagepath = `https://uni-objects.nyc3.cdn.digitaloceanspaces.com/vdc/team-logos/`;
@@ -110,6 +112,15 @@ async function confirmSign(interaction) {
 	// the player is now officially signed, so cancel any pending auto-unsub from a prior sub
 	cancelUnsubTimer(playerData.id);
 
+	await logTransaction({
+		type: TransactionType.SIGN,
+		userID: playerData.id,
+		teamID: team.id,
+		franchiseID: franchise.id,
+		tier: team.tier,
+		details: { contractLength: contractLength, isGM: isGM },
+	});
+
 	const embed = interaction.message.embeds[0];
 	const embedEdits = new EmbedBuilder(embed);
 	embedEdits.setDescription(`This operation was successfully completed.`);
@@ -131,6 +142,11 @@ async function confirmSign(interaction) {
 			{
 				name: `Team`,
 				value: team.name,
+				inline: true,
+			},
+			{
+				name: `Tier`,
+				value: tierLabel(team.tier),
 				inline: true,
 			},
 		],

--- a/src/interactions/subcommands/transactions/sub.js
+++ b/src/interactions/subcommands/transactions/sub.js
@@ -5,6 +5,7 @@ const { ChatInputCommandInteraction, GuildMember } = require(`discord.js`);
 const { Franchise, Player, Team, Transaction, ControlPanel } = require(`../../../../prisma`);
 const { CHANNELS, TransactionsNavigationOptions } = require(`../../../../utils/enums`);
 const { LeagueStatus, ContractStatus } = require("@prisma/client");
+const { registerUnsubTimer, clearUnsubTimer } = require(`../../../helpers/transactions/activeSubTimers`);
 
 const sum = (array) => array.reduce((s, v) => s += v == null ? 0 : v, 0);
 
@@ -141,7 +142,19 @@ async function confirmSub(interaction) {
 	const transactionsChannel = await interaction.guild.channels.fetch(CHANNELS.TRANSACTIONS);
 	await transactionsChannel.send({ embeds: [announcement] });
 
-	setTimeout(async () => {
+	const unsubTimerHandle = setTimeout(async () => {
+		clearUnsubTimer(player.id);
+
+		// The player may have been officially signed or cut during the active sub
+		// window, which clears their ACTIVE_SUB status. Re-fetch and only auto-unsub
+		// if they're still an active sub on the same team, otherwise this stale timer
+		// would wrongly drop a now-signed player from their roster.
+		const currentPlayer = await Player.getBy({ userID: player.id });
+		const isStillActiveSubForTeam =
+			currentPlayer?.Status.contractStatus === ContractStatus.ACTIVE_SUB &&
+			currentPlayer.team === team.id;
+		if (!isStillActiveSubForTeam) return;
+
 		// unsub the player & ensure that the player's team property is now null
 		const updatedPlayer = await Transaction.unsub(player.id);
 		if (updatedPlayer.team !== null) return await interaction.channel.send(`There was an error while attempting to unsub ${guildMember} (${playerTag}). The database was not updated.`);
@@ -160,6 +173,8 @@ async function confirmSub(interaction) {
 
 		return await transactionsChannel.send({ embeds: [announcement] });
 	}, activeSubTime);
+
+	registerUnsubTimer(player.id, unsubTimerHandle);
 }
 module.exports = {
 	requestSub: requestSub,

--- a/src/interactions/subcommands/transactions/sub.js
+++ b/src/interactions/subcommands/transactions/sub.js
@@ -4,8 +4,10 @@ const { ChatInputCommandInteraction, GuildMember } = require(`discord.js`);
 
 const { Franchise, Player, Team, Transaction, ControlPanel } = require(`../../../../prisma`);
 const { CHANNELS, TransactionsNavigationOptions } = require(`../../../../utils/enums`);
-const { LeagueStatus, ContractStatus } = require("@prisma/client");
+const { LeagueStatus, ContractStatus, TransactionType } = require("@prisma/client");
 const { registerUnsubTimer, clearUnsubTimer } = require(`../../../helpers/transactions/activeSubTimers`);
+const { tierLabel, formatTeamWithTier } = require(`../../../helpers/transactions/formatTeam`);
+const { logTransaction } = require(`../../../helpers/transactions/logTransaction`);
 
 const sum = (array) => array.reduce((s, v) => s += v == null ? 0 : v, 0);
 
@@ -20,9 +22,10 @@ async function requestSub(
 	const subInData = await Player.getBy({ discordID: subIn.id });
 	const subOutData = await Player.getBy({ discordID: subOut.id });
 
-	if (subInData === undefined) return await interaction.editReply(`The player you're trying to sub in doesn't exist in the database!`);
-	if (subOutData === undefined) return await interaction.editReply(`The player you're trying to sub out doesn't exist in the database!`);
+	if (subInData == null) return await interaction.editReply(`The player you're trying to sub in doesn't exist in the database!`);
+	if (subOutData == null) return await interaction.editReply(`The player you're trying to sub out doesn't exist in the database!`);
 	if (subOutData.team == null) return await interaction.editReply(`The player you're trying to sub out isn't on a team!`);
+	if (subInData.PrimaryRiotAccount == null) return await interaction.editReply(`The player you're trying to sub in doesn't have a linked Riot account & cannot be subbed in!`);
 
 
 	const team = await Team.getBy({ id: subOutData.team });
@@ -108,6 +111,14 @@ async function confirmSub(interaction) {
 	const updatedPlayer = await Transaction.sub({ userID: player.id, teamID: team.id, tier: team.tier });
 	if (updatedPlayer.team !== team.id) return await interaction.editReply(`There was an error while attempting to sub the player. The database was not updated.`);
 
+	await logTransaction({
+		type: TransactionType.SUB,
+		userID: player.id,
+		teamID: team.id,
+		franchiseID: franchise.id,
+		tier: team.tier,
+	});
+
 	const embed = interaction.message.embeds[0];
 	const embedEdits = new EmbedBuilder(embed);
 	embedEdits.setDescription(`This operation was successfully completed.`);
@@ -131,6 +142,11 @@ async function confirmSub(interaction) {
 			{
 				name: `Team`,
 				value: team.name,
+				inline: true,
+			},
+			{
+				name: `Tier`,
+				value: tierLabel(team.tier),
 				inline: true,
 			}
 		],
@@ -159,10 +175,19 @@ async function confirmSub(interaction) {
 		const updatedPlayer = await Transaction.unsub(player.id);
 		if (updatedPlayer.team !== null) return await interaction.channel.send(`There was an error while attempting to unsub ${guildMember} (${playerTag}). The database was not updated.`);
 
+		await logTransaction({
+			type: TransactionType.UNSUB,
+			userID: player.id,
+			teamID: team.id,
+			franchiseID: franchise.id,
+			tier: team.tier,
+			details: { trigger: `auto` },
+		});
+
 		// create the base embed
 		const announcement = new EmbedBuilder({
 			author: { name: `VDC Transactions Manager` },
-			description: `${guildMember} (${playerTag})'s temporary contract with ${team.name} has ended!`,
+			description: `${guildMember} (${playerTag})'s temporary contract with ${formatTeamWithTier(team)} has ended!`,
 			thumbnail: {
 				url: `https://uni-objects.nyc3.cdn.digitaloceanspaces.com/vdc/team-logos/${franchise.Brand.logo}`,
 			},

--- a/src/interactions/subcommands/transactions/trade.js
+++ b/src/interactions/subcommands/transactions/trade.js
@@ -5,8 +5,9 @@ const { ChatInputCommandInteraction, ButtonInteraction, StringSelectMenuInteract
 const { Franchise, Player, Transaction, ControlPanel } = require(`../../../../prisma`);
 const { prisma } = require("../../../../prisma/prismadb");
 const { CHANNELS, ROLES, TransactionsNavigationOptions } = require(`../../../../utils/enums`);
-const { Tier, LeagueStatus } = require("@prisma/client");
+const { Tier, LeagueStatus, TransactionType } = require("@prisma/client");
 const { updateMeilisearchPlayer } = require("../../../../utils/web/vdcWeb");
+const { logTransaction } = require("../../../helpers/transactions/logTransaction");
 
 const imagepath = `https://uni-objects.nyc3.cdn.digitaloceanspaces.com/vdc/team-logos/`;
 const emoteregex = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
@@ -127,6 +128,16 @@ async function confirmTrade(/** @type ButtonInteraction */ interaction) {
 	const f2PA = f2PlayerOffers.map(fp => `\`U\` | [\`${fp.riotIGN}\`](${fp.trackerURL}) - ${fp.name}`)
 	const f2DPA = f2DraftPickOffers.map(fdp => `\`P\` | \`${fdp.tier}\` - Round ${fdp.round}, Pick ${fdp.pick}, (${fdp.overallPick})`);
 	const f2Gives = [...f2PA, ...f2DPA];
+
+	await logTransaction({
+		type: TransactionType.TRADE,
+		details: {
+			franchise1: { id: franchise1.id, name: franchise1.name },
+			franchise2: { id: franchise2.id, name: franchise2.name },
+			f1Gives: f1Gives,
+			f2Gives: f2Gives,
+		},
+	});
 
 	// create the base embed
 	const announcement = new EmbedBuilder({

--- a/src/interactions/subcommands/transactions/unsub.js
+++ b/src/interactions/subcommands/transactions/unsub.js
@@ -2,9 +2,11 @@ const { ChatInputCommandInteraction, GuildMember, ButtonBuilder, ButtonStyle } =
 
 const { EmbedBuilder, ActionRowBuilder } = require("discord.js");
 const { Player, Franchise, Transaction, Team } = require("../../../../prisma");
-const { ContractStatus } = require("@prisma/client");
+const { ContractStatus, TransactionType } = require("@prisma/client");
 const { CHANNELS, TransactionsNavigationOptions } = require("../../../../utils/enums");
 const { updateMeilisearchPlayer } = require("../../../../utils/web/vdcWeb");
+const { formatTeamWithTier } = require("../../../helpers/transactions/formatTeam");
+const { logTransaction } = require("../../../helpers/transactions/logTransaction");
 
 /** Send confirmation to Unsub a player
  * @param {ChatInputCommandInteraction} interaction
@@ -81,6 +83,15 @@ async function confirmUnsub(interaction) {
 	const player = await Transaction.unsub(playerData.id);
 	if (player.team !== null) return await interaction.editReply(`There was an error while attempting to unsub the player. The database was not updated.`);
 
+	await logTransaction({
+		type: TransactionType.UNSUB,
+		userID: playerData.id,
+		teamID: team.id,
+		franchiseID: franchise.id,
+		tier: team.tier,
+		details: { trigger: `manual` },
+	});
+
 	const embed = interaction.message.embeds[0];
 	const embedEdits = new EmbedBuilder(embed);
 	embedEdits.setDescription(`This operation was successfully completed.`);
@@ -90,7 +101,7 @@ async function confirmUnsub(interaction) {
 	// create the base embed
 	const announcement = new EmbedBuilder({
 		author: { name: `VDC Transactions Manager` },
-		description: `${guildMember} (${playerTag})'s temporary contract with ${team.name} has ended!`,
+		description: `${guildMember} (${playerTag})'s temporary contract with ${formatTeamWithTier(team)} has ended!`,
 		thumbnail: {
 			url: `https://uni-objects.nyc3.cdn.digitaloceanspaces.com/vdc/team-logos/${franchise.Brand.logo}`,
 		},

--- a/src/interactions/subcommands/transactions/updateTier.js
+++ b/src/interactions/subcommands/transactions/updateTier.js
@@ -4,8 +4,10 @@ const { ChatInputCommandInteraction, GuildMember } = require(`discord.js`);
 
 const { Franchise, Player, Team, Transaction, ControlPanel } = require(`../../../../prisma`);
 const { ROLES, CHANNELS, TransactionsNavigationOptions } = require(`../../../../utils/enums`);
-const { Tier } = require("@prisma/client");
+const { Tier, TransactionType } = require("@prisma/client");
 const { updateMeilisearchPlayer } = require("../../../../utils/web/vdcWeb");
+const { tierLabel } = require("../../../helpers/transactions/formatTeam");
+const { logTransaction } = require("../../../helpers/transactions/logTransaction");
 
 const emoteregex = /(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/g;
 
@@ -91,6 +93,15 @@ async function confirmUpdateTier(interaction) {
 	});
 	if (updatedPlayer.team !== newTeam.id) return await interaction.editReply(`There was an error while attempting to update the player's tier. The database was not updated.`);
 
+	await logTransaction({
+		type: TransactionType.UPDATE_TIER,
+		userID: player.id,
+		teamID: newTeam.id,
+		franchiseID: franchise.id,
+		tier: newTeam.tier,
+		details: { fromTier: data[3], toTier: data[4] },
+	});
+
 	await guildMember.roles.remove([
 		...Object.values(ROLES.LEAGUE),
 		...Object.values(ROLES.TIER),
@@ -146,6 +157,11 @@ async function confirmUpdateTier(interaction) {
 			{
 				name: `Team`,
 				value: newTeam.name,
+				inline: true,
+			},
+			{
+				name: `Tier`,
+				value: tierLabel(newTeam.tier),
 				inline: true,
 			},
 		],


### PR DESCRIPTION
This PR adds new features and fixes.

| Version | Notes |
| - | - |
| 2.1.0  | Transaction embeds now show tier alongside team, transactions are recorded to the new Transaction history table, and a couple of null-related crashes are fixed |

### Changes:

**Tier shown on transaction announcements**
- New `formatTeam` helper (`tierLabel`, `formatTeamWithTier`) to render the ALL_CAPS tier enum for display
- Added a dedicated `Tier` field alongside `Franchise`/`Team` on the sign, cut, sub, renew, expire, and update-tier announcements
- Added the `Franchise`/`Team`/`Tier` field trio to the IR announcement (previously had none)
- Inline `Team (Tier)` on the free-text lines: captain set/remove, manual unsub, and the auto-unsub timer

**Transaction history logging**
- New best-effort `logTransaction` helper: never throws, so a logging failure can't break the transaction or block its announcement
- Records a history row for every transaction: sign, cut, sub, unsub (manual + auto), renew, expire, IR, captain, update-tier, retire, reschedule, schedule-playoff, and trade (one row per trade)
- Depends on the `Transaction` table / prisma changes; until those are deployed it safely no-ops with a warning, so this is prod-safe to ship on its own

**Fixes**
- `sub`: guard against a missing player record (`== null` instead of `=== undefined`) and against subbing in a player with no linked Riot account
- `profile update`: guard against a user with no database record (was crashing on `player.primaryRiotAccountID`)