### PR TITLE
ts part 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@
 ################################################################
 
 # Ignore all compiled & generated files. #######################
-utils/enums/*.js
-prisma/*.js
 cache/*.json
 # These will be compiled/generated locally & on deployment #####
 ################################################################
@@ -14,6 +12,7 @@ cache/*.json
 node_modules
 bin
 project
+dist
 interactions/commands/stash
 utils/commandsStructure/stash
 ################################################################

--- a/bot.js
+++ b/bot.js
@@ -35,36 +35,21 @@ process.on(`warning`, (warning) => {
 
 
 // START HOTRELOAD FILES --------------------------------------------------------------------------
-// create hotreloading for cache
-const mmrCachePath = `./cache/mmrCache.json`;
-const mmrTierLinesCache = `./cache/mmrTierLinesCache.json`;
-const combineCountCache = `./cache/combineCountCache.json`;
+const { readCacheJson, cacheFilePath } = require(`./utils/readCacheJson.js`);
 
-// initial requires
-global.mmrCache = require(mmrCachePath);
-global.mmrTierLinesCache = require(mmrTierLinesCache);
-global.combineCountCache = require(combineCountCache);
+const hotReloadedCaches = [
+    { fileName: `mmrCache.json`, assign: (data) => (global.mmrCache = data) },
+    { fileName: `mmrTierLinesCache.json`, assign: (data) => (global.mmrTierLinesCache = data) },
+    { fileName: `combineCountCache.json`, assign: (data) => (global.combineCountCache = data) },
+];
 
-// create watch files for hot-reloading
-fs.watchFile(mmrCachePath, () => {
-    delete require.cache[require.resolve(mmrCachePath)];
-    global.mmrCache = require(mmrCachePath);
+hotReloadedCaches.forEach(({ fileName, assign }) => {
+    assign(readCacheJson(fileName));
 
-    return logger.log(`INFO`, `Reloaded file: \`${mmrCachePath}\``);
-});
-
-fs.watchFile(mmrTierLinesCache, () => {
-    delete require.cache[require.resolve(mmrTierLinesCache)];
-    global.mmrTierLinesCache = require(mmrTierLinesCache);
-
-    return logger.log(`INFO`, `Reloaded file: \`${mmrTierLinesCache}\``);
-});
-
-fs.watchFile(combineCountCache, () => {
-    delete require.cache[require.resolve(combineCountCache)];
-    global.combineCountCache = require(combineCountCache);
-
-    return logger.log(`INFO`, `Reloaded file: \`${combineCountCache}\``);
+    fs.watchFile(cacheFilePath(fileName), () => {
+        assign(readCacheJson(fileName));
+        return logger.log(`INFO`, `Reloaded file: \`cache/${fileName}\``);
+    });
 });
 // ################################################################################################
 

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "description": "Valorant Draft Circuit's Discord Bot",
   "main": "bot.js",
   "scripts": {
-    "start": "node bot.js",
+    "start": "node dist/bot.js",
     "deploy": "npm run cache && npm run start",
 
     "compile": "tsc -p tsconfig.json",
-    "cache": "node ./cache/cache.js",
-    "dev:start": "nodemon --no-warnings --ignore ./cache/ --ignore ./bin/ bot.js",
-    "dev:compile": "npm run cache && tsc -w -p tsconfig.json",
+    "cache": "node dist/cache/cache.js",
+    "dev:start": "nodemon --no-warnings --watch dist --ignore dist/cache dist/bot.js",
+    "dev:compile": "npm run compile && npm run cache && tsc -w -p tsconfig.json",
     "dev:run": "npm install && npm run compile && npm run cache && npm run dev:start",
     "generate": "prisma generate && (clear || cls)",
     "pull": "prisma db pull --force",

--- a/src/core/botClient.js
+++ b/src/core/botClient.js
@@ -76,7 +76,7 @@ module.exports = class BotClient extends Client {
     loadEvents(directory) {
 
         // get event files & filter by .js files
-        const eventFiles = fs.readdirSync(directory);
+        const eventFiles = fs.readdirSync(path.resolve(__dirname, `../../${directory}`));
         let success = 0;
         let failure = 0;
 
@@ -106,7 +106,7 @@ module.exports = class BotClient extends Client {
      */
     registerSlashCommands(readyClient, directory) {
         // register slash commands (rewrite deploy.js)
-        const slashCommandFiles = fs.readdirSync(directory).filter(f => f.endsWith(`.js`));
+        const slashCommandFiles = fs.readdirSync(path.resolve(__dirname, `../../${directory}`)).filter(f => f.endsWith(`.js`));
         const commandStructures = [];
         let success = 0;
 
@@ -141,7 +141,7 @@ module.exports = class BotClient extends Client {
      */
     loadSlashCommands(directory) {
         // register all slash commands
-        const slashCommandFiles = fs.readdirSync(directory).filter(f => f.endsWith(`.js`));
+        const slashCommandFiles = fs.readdirSync(path.resolve(__dirname, `../../${directory}`)).filter(f => f.endsWith(`.js`));
         let success = 0;
 
         slashCommandFiles.forEach(slashCommandFile => {
@@ -159,7 +159,7 @@ module.exports = class BotClient extends Client {
      * @param {String} directory
      */
     loadButtons(directory) {
-        const buttonFiles = fs.readdirSync(directory);
+        const buttonFiles = fs.readdirSync(path.resolve(__dirname, `../../${directory}`));
         let success = 0;
 
         buttonFiles.forEach(buttonFile => {
@@ -177,7 +177,7 @@ module.exports = class BotClient extends Client {
      * @param {String} directory
      */
     loadSelectMenus(directory) {
-        const selectMenuFiles = fs.readdirSync(directory);
+        const selectMenuFiles = fs.readdirSync(path.resolve(__dirname, `../../${directory}`));
         let success = 0;
 
         selectMenuFiles.forEach(selectMenuFile => {
@@ -196,7 +196,7 @@ module.exports = class BotClient extends Client {
      * @param {String} directory
      */
     loadAutocomplete(directory) {
-        const autocompleteFiles = fs.readdirSync(directory).filter(f => f.endsWith(`.js`));
+        const autocompleteFiles = fs.readdirSync(path.resolve(__dirname, `../../${directory}`)).filter(f => f.endsWith(`.js`));
         let success = 0;
 
         autocompleteFiles.forEach(autocompleteFile => {

--- a/src/core/redis.js
+++ b/src/core/redis.js
@@ -2,7 +2,7 @@ const fs = require(`fs`);
 const path = require(`path`);
 const Redis = require(`ioredis`);
 
-const LUA_DIRECTORY = path.resolve(__dirname, `../../utils/lua`);
+const LUA_DIRECTORY = path.resolve(process.cwd(), `utils/lua`);
 const LUA_SCRIPTS = new Map();
 
 let redisClient;

--- a/src/interactions/autocomplete/team.js
+++ b/src/interactions/autocomplete/team.js
@@ -1,4 +1,5 @@
 const { AutocompleteInteraction } = require(`discord.js`);
+const { readCacheJson } = require(`../../../utils/readCacheJson.js`);
 
 module.exports = {
 
@@ -17,7 +18,7 @@ module.exports = {
 
 
 function teamChoices() {
-    const teamCache = require(`../../../cache/teams.json`);
+    const teamCache = readCacheJson(`teams.json`);
     const teamOptions = [];
 
     teamCache.forEach(team => {

--- a/src/interactions/commands/franchise.js
+++ b/src/interactions/commands/franchise.js
@@ -1,6 +1,7 @@
 const { EmbedBuilder, ActionRowBuilder, StringSelectMenuBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
 
-const franchises = require(`../../../cache/franchises.json`);
+const { readCacheJson } = require(`../../../utils/readCacheJson.js`);
+const franchises = readCacheJson(`franchises.json`);
 const { Franchise } = require("../../../prisma");
 const { info, updateDescription } = require("../subcommands/franchise");
 const imagepath = `https://uni-objects.nyc3.cdn.digitaloceanspaces.com/vdc/team-logos/`;

--- a/src/types/globals.d.ts
+++ b/src/types/globals.d.ts
@@ -1,0 +1,31 @@
+import type { Client, Collection } from "discord.js";
+
+interface BotLogger {
+    log(level: string, ...data: unknown[]): unknown;
+}
+
+interface BotClientGlobals extends Client {
+    config: Record<string, unknown>;
+    environment: string | undefined;
+    slashCommands: Collection<string, unknown>;
+    selectMenus: Collection<string, unknown>;
+    buttons: Collection<string, unknown>;
+    modals: Collection<string, unknown>;
+    autocompletes: Collection<string, unknown>;
+    loadEvents(directory: string): void;
+    loadSlashCommands(directory: string): void;
+    registerSlashCommands(readyClient: Client, directory: string): void;
+    loadButtons(directory: string): void;
+    loadSelectMenus(directory: string): void;
+    loadAutocomplete(directory: string): void;
+}
+
+declare global {
+    var logger: BotLogger;
+    var client: BotClientGlobals;
+    var mmrCache: Record<string, unknown>;
+    var mmrTierLinesCache: Record<string, unknown>;
+    var combineCountCache: unknown[];
+}
+
+export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,12 +6,25 @@
     "moduleResolution": "node",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "strict": false,
+    "strict": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "allowJs": true,
+    "checkJs": false,
+    "outDir": "dist",
+    "rootDir": "."
   },
   "include": [
-    "utils/enums/**/*.ts",
-    "prisma/**/*.ts"
+    "bot.js",
+    "src/**/*",
+    "utils/**/*",
+    "cache/**/*.js",
+    "prisma/**/*.ts",
+    "prisma/prismadb.js"
+  ],
+  "exclude": [
+    "node_modules",
+    "**/node_modules",
+    "dist"
   ]
 }

--- a/utils/commandsStructure/draft.js
+++ b/utils/commandsStructure/draft.js
@@ -1,5 +1,6 @@
 const { Tier } = require(`@prisma/client`);
 const { ApplicationCommandOptionType, InteractionContextType } = require(`discord.js`);
+const { readCacheJson } = require(`../readCacheJson.js`);
 
 /** @type {import('discord.js').RESTPostAPIApplicationCommandsJSONBody} */
 module.exports = {
@@ -240,7 +241,7 @@ module.exports = {
 };
 
 function franchiseChoices() {
-	const franchiseData = require(`../../cache/franchises.json`);
+	const franchiseData = readCacheJson(`franchises.json`);
 	const signOptions = [];
 
 	franchiseData.forEach(franchise => {

--- a/utils/commandsStructure/franchise.js
+++ b/utils/commandsStructure/franchise.js
@@ -1,4 +1,5 @@
 const { ApplicationCommandOptionType, InteractionContextType } = require(`discord.js`);
+const { readCacheJson } = require(`../readCacheJson.js`);
 
 /** @type {import('discord.js').RESTPostAPIApplicationCommandsJSONBody} */
 module.exports = {
@@ -37,7 +38,7 @@ module.exports = {
 }
 
 function franchiseChoices() {
-    const franchiseData = require(`../../cache/franchises.json`);
+    const franchiseData = readCacheJson(`franchises.json`);
     const franchiseOptions = [];
 
     franchiseData.forEach(franchise => {

--- a/utils/commandsStructure/league.js
+++ b/utils/commandsStructure/league.js
@@ -1,5 +1,6 @@
 const { Tier } = require(`@prisma/client`);
 const { ApplicationCommandOptionType, InteractionContextType, PermissionFlagsBits } = require(`discord.js`);
+const { readCacheJson } = require(`../readCacheJson.js`);
 
 /** @type {import('discord.js').RESTPostAPIApplicationCommandsJSONBody} */
 module.exports = {
@@ -114,7 +115,7 @@ module.exports = {
 }
 
 function franchiseChoices() {
-    const franchiseData = require(`../../cache/franchises.json`);
+    const franchiseData = readCacheJson(`franchises.json`);
     const franchiseOptions = [];
 
     franchiseData.forEach(franchise => {

--- a/utils/commandsStructure/transactions.js
+++ b/utils/commandsStructure/transactions.js
@@ -1,5 +1,6 @@
 const { Tier } = require(`@prisma/client`);
 const { ApplicationCommandOptionType, InteractionContextType } = require(`discord.js`);
+const { readCacheJson } = require(`../readCacheJson.js`);
 
 /** @type {import('discord.js').RESTPostAPIApplicationCommandsJSONBody} */
 module.exports = {
@@ -282,7 +283,7 @@ module.exports = {
 }
 
 function franchiseChoices() {
-    const franchiseData = require(`../../cache/franchises.json`);
+    const franchiseData = readCacheJson(`franchises.json`);
     const franchiseChoices = [];
 
     franchiseData.forEach(franchise => {

--- a/utils/readCacheJson.ts
+++ b/utils/readCacheJson.ts
@@ -1,0 +1,11 @@
+import fs from "fs";
+import path from "path";
+
+export function cacheFilePath(fileName: string): string {
+    return path.resolve(process.cwd(), "cache", fileName);
+}
+
+export function readCacheJson<T>(fileName: string): T {
+    const rawContents = fs.readFileSync(cacheFilePath(fileName), "utf-8");
+    return JSON.parse(rawContents) as T;
+}


### PR DESCRIPTION
This PR adds new features and fixes.

| Version | Notes |
| - | - |
| 2.1.0 | TypeScript migration part 1: build foundation (strict tsconfig, dist output, runtime path re-rooting) |

### Changes:

**Build system**
- `tsconfig.json` rewritten for the migration: `strict: true`, `outDir: dist`, `rootDir: .`, `allowJs`/`checkJs: false` so unconverted JS passes through to `dist` unchecked while every `.ts` file is type-checked strictly
- All compiled output now goes to `dist/`; in-place emit is gone and 19 stale generated `.js` siblings were removed from `utils/enums/` and the `prisma` submodule
- npm scripts point at the compiled tree: `start` runs `node dist/bot.js`, `cache` runs `node dist/cache/cache.js`, `dev:start` watches `dist` (works with `dev:compile`'s `tsc -w`)
- `.gitignore`: ignores `dist`, drops the obsolete in-place-emit entries; Dockerfile needs no changes

**Runtime path fixes (required for running from dist)**
- New `utils/readCacheJson.ts` helper (first strict TS source file): reads cache JSON from `<cwd>/cache/`, so compiled code in `dist` and generated data at the repo root never disagree
- `bot.js` cache hot-reload rewritten to use the helper with `fs.watchFile` instead of `require.cache` deletion; watched paths now match where `cache.js` actually writes
- Six `require(...cache/*.json)` call sites converted to the helper (`autocomplete/team`, `commands/franchise`, and four `utils/commandsStructure` files); these now read fresh data instead of a stale module-cached copy
- `src/core/redis.js` resolves lua scripts from the working directory instead of `__dirname`
- `src/core/botClient.js` loader fix: `readdirSync` scans now target the same compiled directory the `require` calls load from; previously the scan hit the source tree, which would have silently dropped every command once sources are renamed to `.ts`

**Types**
- New `src/types/globals.d.ts` declaring `global.logger`, `global.client`, and the three cache globals (shallow types, to be tightened as `src/core` is converted)
- `prisma/_Player.ts` (submodule): typed the `sum` helper to satisfy strict mode

**Notes for reviewers**
- No behavior changes intended beyond fresher cache reads noted above; the bot was smoke-tested (startup loader counts, franchise command, autocomplete, cache hot reload)
- This is chunk 1 of an incremental migration; next chunk converts `src/core` to strict TS