### PR TITLE
add guards for mmr cache

### DIFF
--- a/cache/cache.js
+++ b/cache/cache.js
@@ -105,11 +105,13 @@ async function buildMMRCache() {
         }
     });
 
-    const mapped = playerMMRs.map((p) => {
-        const disc = p.Accounts[0].providerAccountId;
-        const mmr = p.PrimaryRiotAccount?.MMR?.mmrEffective;
-        return { discordID: disc, mmr: mmr, ls: p.Status.leagueStatus, cs: p.Status.contractStatus};
-    }).filter((p => p.mmr !== null && p.mmr !== undefined));
+    const mapped = playerMMRs
+        .filter((p) => p.Accounts.length > 0 && p.Status !== null)
+        .map((p) => {
+            const disc = p.Accounts[0].providerAccountId;
+            const mmr = p.PrimaryRiotAccount?.MMR?.mmrEffective;
+            return { discordID: disc, mmr: mmr, ls: p.Status.leagueStatus, cs: p.Status.contractStatus};
+        }).filter((p => p.mmr !== null && p.mmr !== undefined));
 
     const tierLines = await ControlPanel.getMMRCaps(`PLAYER`);
 

--- a/src/interactions/subcommands/debug/refreshCache.js
+++ b/src/interactions/subcommands/debug/refreshCache.js
@@ -27,11 +27,13 @@ async function buildMMRCache() {
         }
     });
 
-    const mapped = playerMMRs.map((p) => {
-        const disc = p.Accounts[0].providerAccountId;
-        const mmr = p.PrimaryRiotAccount?.MMR?.mmrEffective;
-        return { discordID: disc, mmr: mmr, ls: p.Status.leagueStatus, cs: p.Status.contractStatus};
-    }).filter((p => p.mmr !== null && p.mmr !== undefined));
+    const mapped = playerMMRs
+        .filter((p) => p.Accounts.length > 0 && p.Status !== null)
+        .map((p) => {
+            const disc = p.Accounts[0].providerAccountId;
+            const mmr = p.PrimaryRiotAccount?.MMR?.mmrEffective;
+            return { discordID: disc, mmr: mmr, ls: p.Status.leagueStatus, cs: p.Status.contractStatus};
+        }).filter((p => p.mmr !== null && p.mmr !== undefined));
 
     const tierLines = await ControlPanel.getMMRCaps(`PLAYER`);
 


### PR DESCRIPTION
…d Discord account

This PR adds new features and fixes.

| Version | Notes |
| - | - |
| 3.0.1  | MMR cache guard |

### Changes:
- a pre-existing bug in `buildMMRCache,`: it maps every `User` row and blindly indexes their first Discord account. Someone in the prod DB now has a user row with no linked Discord account (or the deploy is just the first since that row appeared), and the cache build died on them.
 - The guard now skips users lacking a Discord account or a Status row